### PR TITLE
Fix crash when worker is not a Class but a String

### DIFF
--- a/lib/sidekiq/debounce.rb
+++ b/lib/sidekiq/debounce.rb
@@ -4,7 +4,7 @@ require 'sidekiq/api'
 module Sidekiq
   class Debounce
     def call(worker, msg, _queue, redis_pool)
-      @worker = worker
+      @worker = worker.is_a?(String) ? worker.constantize : worker
       @msg = msg
 
       return yield unless debounce?


### PR DESCRIPTION
Fixes #1, as promised.

Tests didn't pass on my machine without this, so I didn't add a test or anything. Now they pass :)

PS. Should probably isolate which change (Sidekiq version?) breaks this and add that to travis for testing. Are you familiar with the `gemfiles` thingie TravisCI provides? :) (http://docs.travis-ci.com/user/build-configuration/)
