### PR TITLE
Update gemspec; does not support Sidekiq 3.0, only 3.1+

### DIFF
--- a/sidekiq-debounce.gemspec
+++ b/sidekiq-debounce.gemspec
@@ -25,7 +25,7 @@ DESC
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'sidekiq', '>= 3.0'
+  spec.add_dependency 'sidekiq', '>= 3.1.0'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'mock_redis'


### PR DESCRIPTION
Tested this on 3.0.0, 3.0.1 and 3.0.2, neither of them worked, so I figured the gemspec should be changed accordingly :)

PS. Tests fail because TravisCI runs them against latest Sidekiq version and the fix for #1 is not in this branch.
