### PR TITLE
TravisCI: Test against Sidekiq 3.1.0 and 3.3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ rvm:
  - 2.0.0
  - 2.1.2
  - jruby-9.0.0.0.pre1
+gemfile:
+- gemfiles/Gemfile.sidekiq-3.1.0
+- gemfiles/Gemfile.sidekiq-3.3.4
 script: bundle exec rake test
 addons:
  code_climate:

--- a/gemfiles/Gemfile.sidekiq-3.1.0
+++ b/gemfiles/Gemfile.sidekiq-3.1.0
@@ -1,0 +1,5 @@
+source "http://rubygems.org"
+
+gem 'sidekiq', '3.1.0'
+
+gemspec path: '../'

--- a/gemfiles/Gemfile.sidekiq-3.3.4
+++ b/gemfiles/Gemfile.sidekiq-3.3.4
@@ -1,0 +1,5 @@
+source "http://rubygems.org"
+
+gem 'sidekiq', '3.3.4'
+
+gemspec path: '../'


### PR DESCRIPTION
Could not test this, but this should run two separate runs on TravisCI each with different versions of Sidekiq.
- 3.1.0 is the oldest Sidekiq version where tests pass
- 3.3.4 is the version where the bug described in #1 happens

This branch does not have the fix for #1 so TravisCI build should fail when using sidekiq334.gemfile
