### PR TITLE
store jid only. check if the job is still there before rescheduling

### DIFF
--- a/lib/sidekiq/debounce.rb
+++ b/lib/sidekiq/debounce.rb
@@ -26,7 +26,7 @@ module Sidekiq
     private
 
     def store_expiry(conn, jid, time)
-      conn.set(debounce_key, jid)
+      conn.set(debounce_key, jid['jid'])
       conn.expireat(debounce_key, time.to_i)
     end
 
@@ -41,6 +41,8 @@ module Sidekiq
 
     def reschedule(jid, at)
       job = scheduled_set.find_job(jid)
+      return jid if job.nil?
+      
       job.reschedule(at)
       jid
     end


### PR DESCRIPTION
Scheduling a job in a very quick timescale (10 milliseconds) will result in job not being found when `reschedule` is called.

Also, `schedule_set` now uses the `jid` instead of the whole serialised object to find the job. It was not finding it before at all.
