### PR TITLE
README: Change description of how long debounce blocks new jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ easily rate-limit creation of Sidekiq jobs.
 
 When you create a job via `#perform_in` on a Worker with debounce enabled,
 Sidekiq::Debounce will prevent other jobs with the same arguments from being
-created until the job has run.  Every time you create another job with those
+created until the time has passed. Every time you create another job with those
 same arguments prior to the job being run, the timer is reset and the entire
 period must pass again before the job is executed.
 


### PR DESCRIPTION
Changes the description for how debounce blocks re-scheduling: the gem does not guarantee that the job is not scheduled multiple times before it has been run, but instead, guarantees that a job is not scheduled multiple times within a certain timespan.

Sidekiq might be busy running other workers while the debounce_key expires and then the job will be rescheduled, so this change makes it implicit that this is how the gem works :)
