### PR TITLE
Don't reschedule if the job is gone

### DIFF
--- a/lib/sidekiq/debounce.rb
+++ b/lib/sidekiq/debounce.rb
@@ -41,7 +41,7 @@ module Sidekiq
 
     def reschedule(jid, at)
       job = scheduled_set.find_job(jid)
-      job.reschedule(at)
+      job.reschedule(at) unless job.nil?
       jid
     end
 


### PR DESCRIPTION
Only reschedule the job if it's still there. Fixes behaviour where, with a very low debounce time, the job was sometimes processed multiple times.
