### PR TITLE
Fix CodeClimate > 1 breakage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,5 @@ script: bundle exec rake test
 addons:
  code_climate:
   repo_token: b11e6d8ed83dd2e01424b088c469e2cef525a89e887414f81e6ee7f36b937a1d
+after_success:
+ - bundle exec codeclimate-test-reporter

--- a/sidekiq-debounce.gemspec
+++ b/sidekiq-debounce.gemspec
@@ -30,6 +30,7 @@ DESC
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'mock_redis'
   spec.add_development_dependency 'mocha'
-  spec.add_development_dependency 'codeclimate-test-reporter'
+  spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'codeclimate-test-reporter', '~> 1.0.0'
   spec.add_development_dependency 'minitest'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
+require 'simplecov'
+SimpleCov.start
+
 require 'minitest/spec'
 require 'minitest/autorun'
 require 'mocha/mini_test'
 require 'sidekiq_helper'
-require 'codeclimate-test-reporter'
-
-CodeClimate::TestReporter.start


### PR DESCRIPTION
The current usage of CodeClimate prevents tests from being executed. This PR updates the code in accordance with this [doc](https://docs.codeclimate.com/v1.0/docs/travis-ci-ruby-test-coverage).

Resolves #13 