### PR TITLE
Manually deleted schedules

### DIFF
--- a/sidekiq-debounce.gemspec
+++ b/sidekiq-debounce.gemspec
@@ -33,4 +33,5 @@ DESC
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'codeclimate-test-reporter', '~> 1.0.0'
   spec.add_development_dependency 'minitest'
+  spec.add_development_dependency 'activesupport'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,5 +3,6 @@ SimpleCov.start
 
 require 'minitest/spec'
 require 'minitest/autorun'
-require 'mocha/mini_test'
+require 'mocha/minitest'
 require 'sidekiq_helper'
+require "active_support/inflector"


### PR DESCRIPTION
"debounce_key" has an expiry, but this redis key will be deleted only when the expiry is over.
https://github.com/hummingbird-me/sidekiq-debounce/blob/c1b1779c2b60befb13096906ded4babca13e7e27/lib/sidekiq/debounce.rb#L37

If a scheduled job is manually deleted (either from API or webUI) **BEFORE** its expiry, since the debounce_key will still be there in redis, the worker's `perform_in` will just be ignored, instead of creating a new job.

Adding this line is the main purpose of this PR.
https://github.com/github0013/sidekiq-debounce/blob/1009766b5556b03e5efd72cfe777f8df57fadc58/lib/sidekiq/debounce.rb#L22